### PR TITLE
Add typing to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     url='https://github.com/mayhewj/greenstalk',
     license='MIT',
     py_modules=['greenstalk'],
+    install_requires=['typing'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
After installing this module (version 0.5.0) from PyPI on Debian Stretch, I got the following error:

```
>>> import greenstalk
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/user/programming/queue-test/venv/lib/python3.4/site-packages/greenstalk.py", line 2, in <module>
    from typing import Any, BinaryIO, Dict, Iterable, List, Optional, Tuple, Union
ImportError: No module named 'typing'
```

After installing the typing module (at version 3.6.1) it worked fine.