### PR TITLE
Fix tests.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -357,7 +357,7 @@ def test_delete_job_reserved_by_other(c: Client) -> None:
     with pytest.raises(NotFoundError):
         c.delete(job)
     time.sleep(1)
-    c.delete(job)
+    other.delete(job)
 
 
 @with_beanstalkd()


### PR DESCRIPTION
Tests are failing (reproduced on `1.0.0` and `master`) with :

```
========================================== FAILURES ===========================================
______________________________ test_delete_job_reserved_by_other ______________________________

    def wrapper() -> None:
        cmd = ('beanstalkd', '-l', '127.0.0.1', '-p', str(PORT))
        with subprocess.Popen(cmd) as beanstalkd:
            time.sleep(0.1)
            try:
                with Client(port=PORT, **kwargs) as c:
>                   test(c)

tests.py:27: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests.py:360: in test_delete_job_reserved_by_other
    c.delete(job)
greenstalk.py:253: in delete
    self._send_cmd(b'delete %d' % _to_id(job), b'DELETED')
greenstalk.py:172: in _send_cmd
    return _parse_response(line, expected)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

line = b'NOT_FOUND', expected = b'DELETED'

    def _parse_response(line: bytes, expected: bytes) -> List[bytes]:
        if not line:
            raise ConnectionError("Unexpected EOF")
    
        assert line[-2:] == b'\r\n'
        line = line[:-2]
    
        status, *values = line.split()
    
        if status == expected:
            return values
    
        if status in ERROR_RESPONSES:
>           raise ERROR_RESPONSES[status](values)
E           greenstalk.NotFoundError: []

greenstalk.py:396: NotFoundError
============================ 1 failed, 35 passed in 11.09 seconds =============================
```

I guess the other job must be deleted by its owner, so here is a patch for it.