### PR TITLE
Add destructor to Client.

### DIFF
--- a/greenstalk.py
+++ b/greenstalk.py
@@ -154,6 +154,9 @@ class Client:
             if DEFAULT_TUBE not in watch:
                 self.ignore(DEFAULT_TUBE)
 
+    def __del__(self) -> None:
+        self.close()
+
     def __enter__(self) -> 'Client':
         return self
 


### PR DESCRIPTION
This adds the destructor to the client to clean up connections.

Without it, unittest may return errors:

```
/usr/lib/python3.6/socket.py:657: ResourceWarning: unclosed <socket.socket fd=15, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('127.0.0.1', 42328), raddr=('127.0.0.1', 11300)>
  self._sock = None
```